### PR TITLE
uncomment the release notes so it builds again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
            </configuration> 
           </execution>  
           
-          <!--         <execution>
+          <execution>
             <id>rcbu-release-notes</id>
             <goals>
               <goal>generate-webhelp</goal>
@@ -61,7 +61,7 @@
               <feedbackEmail>catherine.richardson@rackspace.com</feedbackEmail>
             </configuration>
           </execution> 
--->         
+
           <execution>
             <id>rcbu-getting-started</id>
             <goals>


### PR DESCRIPTION
@cyrichardson: @j12y and I are trying to get the release notes working on the new docs. It appears the release notes had been commented out of the pom at some point.  This should add it back in.  If it looks good to you, please merge.  Thanks!