### PR TITLE
Changed GSG examples to use environment variables in the request.

### DIFF
--- a/rst/dev-guide/cloud-backup-v1/common-gs/auth-using-curl.rst
+++ b/rst/dev-guide/cloud-backup-v1/common-gs/auth-using-curl.rst
@@ -34,6 +34,10 @@ In the following example, the ellipsis (...)  represents other service endpoints
 are not shown. The values shown in this and other examples vary because the information
 returned is specific to your account.
 
+.. note:: 
+     For a detailed description of the information included in the authentication response, see 
+     :rax-devdocs:`Annotated authentication request and response<cloud-identity/v2/developer-guide/#document-authentication-info/sample-auth-req-response>`.
+
 **Example: Authentication response**
 
 .. include:: ../common-gs/samples/auth-resp-json.rst
@@ -46,18 +50,14 @@ authentication response. You'll need these values to submit requests to the API.
 If the request failed, review the response message and
 the following error message descriptions to determine next steps.
 
-``400 Invalid request body: unable to parse Auth data. Please review XML or JSON formatting``
+``400 Invalid request body: unable to parse Auth data. Please review XML or JSON formatting``:Review the 
+authentication request for syntax or coding errors. If you are using cURL, see the 
+:ref:`Using cURL <how-curl-commands-work>`.
 
-  Review the authentication request for syntax or coding errors.
-  If you are using cURL, see the :ref:`Using cURL <how-curl-commands-work>`.
 
-
-``401 Unable to authenticate user with credentials provided.``
-
-  Verify the authentication credentials submitted in the
-  authentication request. If necessary, contact your Rackspace
-  Cloud Administrator or Rackspace Support to get valid
-  credentials.
+``401 Unable to authenticate user with credentials provided.``: Verify the authentication credentials 
+submitted in theauthentication request. If necessary, contact your Rackspace Cloud Administrator 
+or Rackspace Support to get valid credentials.
 
 ..  note::
        For additional information about authentication errors, see the

--- a/rst/dev-guide/cloud-backup-v1/general-api-info/authentication.rst
+++ b/rst/dev-guide/cloud-backup-v1/general-api-info/authentication.rst
@@ -1,119 +1,19 @@
-.. _general-auth:
+.. _authentication-ovw:
 
-==============
+~~~~~~~~~~~~~~
 Authentication
-==============
+~~~~~~~~~~~~~~
+Each REST request against the Cloud Backup service requires the inclusion of a specific
+authorization token, supplied in the ``X-Auth-Token`` HTTP header of each API request.
+You get a token by submitting an authentication request with valid account credentials to
+the following Rackspace Cloud Identity API service endpoint:
 
-Every REST request against the Rackspace Cloud Backup Service requires the inclusion of a specific authorization token, supplied by the `X-Auth-Token` HTTP header. Customers obtain this token by first using the Rackspace Cloud Identity Service and supplying a valid user name and API access key.
+.. code::
 
-To authenticate, submit a `POST/v2.0/tokens` request, presenting valid Rackspace customer credentials in the message body to a Rackspace authentication endpoint.
+       https://identity.api.rackspacecloud.com/v2.0
 
-.. _auth-cred:
+For details see the following information:
 
-Get your credentials
-~~~~~~~~~~~~~~~~~~~~
-
-You can use either of two sets of credentials:
-
--  your user name and password
-
--  your user name and API key
-
-Your user name and password are the ones that you use to login to the Cloud Control Panel. After you are logged in, you can use the Cloud Control Panel to obtain your API key.
-
-.. note::
-  If you authenticate with username and password credentials, you can set up multi-factor authentication to add an additional level of security to your account. This feature is not available for username and API credentials. For information about setting up and using multi-factor authentication, see :rax-devdocs:`Multi-factor authentication <cloud-identity/v2/developer-guide/#document-authentication-info/use-mfa-ops>`.
-
-**To find your API key:**
-
-#. Log in to the Cloud Control Panel (https://mycloud.rackspace.com).
-
-#. On the upper-right side of the top navigation pane, click your
-   username.
-
-#. From the menu, select **Account Settings**.
-
-#. In the Login Details section of the Account Settings page, locate the
-   **API Key** field and click **Show**.
-
-#. Copy the value of the API key and paste it into a text editor of your
-   choice.
-
-#. Click **Hide** to hide the value of the API key.
-
-You also need your cloud account number. In the documentation, the account number is often referred to as your tenant name or tenant ID (technically, the ID is different from the name, but at Rackspace, they are the same thing). Together, three components—your user name, your API key, and your tenant ID or cloud account number—form the authentication credentials that are required to connect to the Rackspace cloud.
-
-To find your tenant ID or cloud account number, locate your user name on the upper-right side of the top navigation pane in the Cloud Control Panel. The tenant ID or account number is in parentheses just to the right of your user name.
-
-.. _auth-global:
-
-Use the global authentication endpoint
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Use the following global endpoint to access the Cloud Identity Service:
-
-``https://identity.api.rackspacecloud.com/v2.0/``
-
-.. _auth-send:
-
-Send your credentials to your authentication endpoint
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you know your credentials and your authentication endpoint, and you can issue a `POST /v2.0/tokens` request in an API call, you have all the basic information that you need to use the Rackspace Cloud Identity Service.
-
-You can use `cURL`_ to try the authentication process in two steps: 1) get a token; 2) send the token to a service.
-
-1. Get an authentication token by providing your user name and either your API key or your password. Following are examples of both approaches:
-
-  - You can request a token by providing your user name and your API key.
-
-  .. code::
-
-          curl -X POST https://auth.api.rackspacecloud.com/v2.0/tokens -d 
-          '{ "auth":{ "RAX-KSKEY:apiKeyCredentials":{ "username":"yourUserName", "apiKey":"yourApiKey" } } }' -H "Content-type: application/json"
-
-  - You can request a token by providing your user name and your password.
-
-    .. code:: 
-
-          curl -X POST https://auth.api.rackspacecloud.com/v2.0/tokens -d
-          '{"auth":{"passwordCredentials":{"username":"yourUserName","password":"yourPassword"}}}' -H "Content-type: application/json"
-
-2. Review the authentication response.
-
-  - Successful authentication returns a token that you can use as evidence that your identity has already been authenticated. To use the token, pass it to other services as in the `X-Auth-Token` header.
-
-  - If the Identity service returns a returns a 401 message with a request for additional credentials, your account requires multi-factor authentication. To complete the authentication process, submit a second POST tokens request with these multi-factor authentication credentials:
-
-    * The session ID value returned in the WWW-Authenticate: OS-MF sessionId header parameter that is included in the response to the initial authentication request.
-
-    * The passcode from the mobile phone associated with your user account.
-
-    **Example: Authentication request with multi-factor authentication credentials**
-
-      .. code::
-
-        $ curl https://identity.api.rackspacecloud.com/v2.0/tokens \
-          -X POST \
-          -d '{"auth": {"RAX-AUTH:passcodeCredentials": {"passcode":"1411594"}}}'\
-          -H "X-SessionId: $SESSION_ID" \
-          -H "Content-Type: application/json" --verbose | python -m json.tool
-
-3. Use the authentication token to send a **GET** to a service you would like to use. Here is an example of passing an authentication token to the Cloud Files service, using the Cloud Files service catalog endpoint that was returned along with the token.
-
-  .. code::
-
-    curl -X GET https://storage101.dfw1.clouddrive.com/v1/MossoCloudFS_aaaaaaaa-bbbb-cccc-dddd-eeeeeeee
-    -H 'X-Auth-Token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' --verbose 
-
-Authentication tokens are typically valid for 24 hours. Applications should be designed to re-authenticate after receiving a 401 (Unauthorized) response from a service endpoint.
-
-.. note:: 
-  If you are programmatically parsing an authentication response, be aware that service names are stable for the life of the particular service and can be used as keys. You should also be aware that a user's service catalog can include multiple uniquely-named services that perform similar functions. For example, cloudServersOpenStack is the OpenStack version of compute whereas cloudServers is the legacy version of compute. The same user can have access to both services. In the Cloud Identity Service v2.0, the service type attribute can be used as a key to recognize similar services. See the following tip.
-
-..  tip:: 
-  Beginning with Rackspace Cloud Identity Service v2.0 (earlier versions were called Rackspace Cloud Authentication Service), the service catalog includes a service type attribute to identify services that perform similar functions but have different names; for example, `type="compute"` identifies compute services such as cloudServers and cloudServersOpenStack. Some developers have found the service type attribute to be useful in parsing the service catalog. For Cloud Identity Service v2.0, you can see the service type attribute in :rax-devdocs:`Annotated authentication request and response <cloud-identity/v2/developer-guide/#document-authentication-info/sample-auth-req-response>`.
-
-
-.. _cURL: http://curl.haxx.se/
-
+- :ref:`Authenticate to the Rackspace Cloud<authenticate-to-cloud>`
+- :rax-devdocs:`Rackspace Cloud Identity API developer documentation
+  <cloud-identity/v2/developer-guide/>`

--- a/rst/dev-guide/cloud-backup-v1/general-api-info/service-access-endpoints.rst
+++ b/rst/dev-guide/cloud-backup-v1/general-api-info/service-access-endpoints.rst
@@ -12,25 +12,25 @@ To help you decide which regionalized endpoint to use, read the Knowledge Center
 
 **Regionalized service endpoints**
 
-+---------------------+-------------------------------------------------------+
-| Region              | Endpoint                                              |
-+=====================+=======================================================+
-| Dallas/Ft. Worth    | ``https://dfw.backup.api.rackspacecloud.com/v2/1234/``|
-| (DFW)               |                                                       |
-+---------------------+-------------------------------------------------------+
-| Chicago (ORD)       | ``https://ord.backup.api.rackspacecloud.com/v2/1234/``|
-+---------------------+-------------------------------------------------------+
-| London (LON)        | ``https://lon.backup.api.rackspacecloud.com/v2/1234/``|
-+---------------------+-------------------------------------------------------+
-| Hong Kong (HKG)     | ``https://hkg.backup.api.rackspacecloud.com/v2/1234/``|
-+---------------------+-------------------------------------------------------+
-| Northern Virginia   | ``https://iad.backup.api.rackspacecloud.com/v2/1234/``|
-| (IAD)               |                                                       |
-+---------------------+-------------------------------------------------------+
-| Sydney (SYD)        | ``https://syd.backup.api.rackspacecloud.com/v2/1234/``|
-+---------------------+-------------------------------------------------------+
++---------------------+---------------------------------------------------------+
+| Region              | Endpoint                                                |
++=====================+=========================================================+
+| Dallas/Ft. Worth    | ``https://dfw.backup.api.rackspacecloud.com/v2/123456/``|
+| (DFW)               |                                                         |
++---------------------+---------------------------------------------------------+
+| Chicago (ORD)       | ``https://ord.backup.api.rackspacecloud.com/v2/123456/``|
++---------------------+---------------------------------------------------------+
+| London (LON)        | ``https://lon.backup.api.rackspacecloud.com/v2/123456/``|
++---------------------+---------------------------------------------------------+
+| Hong Kong (HKG)     | ``https://hkg.backup.api.rackspacecloud.com/v2/123456/``|
++---------------------+---------------------------------------------------------+
+| Northern Virginia   | ``https://iad.backup.api.rackspacecloud.com/v2/123456/``|
+| (IAD)               |                                                         |
++---------------------+---------------------------------------------------------+
+| Sydney (SYD)        | ``https://syd.backup.api.rackspacecloud.com/v2/123456/``|
++---------------------+---------------------------------------------------------+
 
-Replace the sample account ID number (which is also called the tenant ID), 1234, with your actual account number that is returned as part of the Cloud Identity service response.
+Replace the sample account ID number (which is also called the tenant ID), 123456, with your actual account number that is returned as part of the Cloud Identity service response.
 
 You will find the actual account number after the final slash (/) in the ``publicURL`` field returned by the authentication response.
 

--- a/rst/dev-guide/cloud-backup-v1/getting-started/examples/check-backup-status.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/examples/check-backup-status.rst
@@ -9,15 +9,6 @@ not, what errors occurred.
 The HTTP request must include a header to specify the authentication
 token.
 
-The cURL request uses the ``-s`` option for silent or quiet mode (no
-progress or error messages shown) and the ``-X`` option to specify the
-request operation to use when communicating with the HTTP server
-(instead of using the default operation).
-
-If you have the tools, you can run the cURL JSON request examples with
-the following option to format the output from cURL: **<cURL JSON
-request example> \| python -m json.tool**.
-
 The following example output shows ``"CurrentState": "Queued"``. Other
 valid values for ``CurrentState`` are as follows:
 
@@ -45,15 +36,16 @@ valid values for ``CurrentState`` are as follows:
 
 An HTTP status code of 200 (OK) in the response indicates that the
 request succeeded.
-
  
-**Example: Checking backup status**
+**cURL check backup status request**
 
 .. code::  
 
-   curl -s -X GET https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/backup/yourBackupID \
-   -H "X-Auth-Token: yourAuthToken" \
+   curl -s -X GET $API_ENDPOINT/v1.0/$TENANT_ID/backup/yourBackupID \
+   -H "X-Auth-Token: $AUTH_TOKEN" \
    -H "Content-Type: application/json | python -m json.tool
+
+**Check backup status response**
 
 .. code::  
 

--- a/rst/dev-guide/cloud-backup-v1/getting-started/examples/create-backup-config.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/examples/create-backup-config.rst
@@ -22,25 +22,15 @@ with small changes for each server that you create.
 The HTTP request must include a header to specify the authentication
 token.
 
-The cURL request uses the ``-s`` option for silent or quiet mode (no
-progress or error messages shown) and the ``-X`` option to specify the
-request operation to use when communicating with the HTTP server
-(instead of using the default operation).
-
-If you have the tools, you can run the cURL JSON request examples with
-the following option to format the output from cURL: **<cURL JSON
-request example> \| python -m json.tool**.
-
 An HTTP status code of 200 (OK) in the response indicates that the
 request succeeded.
-
  
-**Example: Create a backup configuration**
+**cURL create a backup configuration request**
 
 .. code::  
 
-   curl -s -X POST https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/backup-configuration \
-   -H "X-Auth-Token: yourAuthToken" \
+   curl -s -X POST $API_ENDPOINT/v1.0/$TENANT_ID/backup-configuration \
+   -H "X-Auth-Token: $AUTH_TOKEN" \
    -H "Content-Type: application/json" \
    -d '{
         "MachineAgentId": 202743,
@@ -76,6 +66,8 @@ request succeeded.
         ]
     }'  | python -m json.tool 
      
+
+**Create a backup configuration response**
 
 .. code::  
 

--- a/rst/dev-guide/cloud-backup-v1/getting-started/examples/create-restore-config.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/examples/create-restore-config.rst
@@ -12,25 +12,16 @@ same folder on the same server. You must set the ``BackupMachineId``,
 The HTTP request must include a header to specify the authentication
 token.
 
-The cURL request uses the ``-s`` option for silent or quiet mode (no
-progress or error messages shown) and the ``-X`` option to specify the
-request operation to use when communicating with the HTTP server
-(instead of using the default operation).
-
-If you have the tools, you can run the cURL JSON request examples with
-the following option to format the output from cURL: **<cURL JSON
-request example> \| python -m json.tool**.
-
 An HTTP status code of 200 (OK) in the response indicates that the
 request succeeded.
 
  
-**Example: Create a restore configuration**
+**cURL create a restore configuration request**
 
 .. code::  
 
-   curl -s -X PUT https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/restore /
-   -H "X-Auth-Token: yourAuthToken" \
+   curl -s -X PUT $API_ENDPOINT/v1.0/$TENANT_ID/restore /
+   -H "X-Auth-Token: $AUTH_TOKEN" \
    -H "Content-Type: application/json" \
    -d '{ "BackupId": 368785,
           "BackupMachineId": 157512, 
@@ -38,6 +29,7 @@ request succeeded.
           "DestinationPath": "C:\\FolderPathForRestore\\", 
           "OverwriteFiles": false }' | python -m json.tool 
       
+**Create a restore configuration response**
 
 .. code::  
 

--- a/rst/dev-guide/cloud-backup-v1/getting-started/examples/delete-backup-config.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/examples/delete-backup-config.rst
@@ -13,31 +13,28 @@ removed.
 The HTTP request must include a header to specify the authentication
 token.
 
-The cURL request uses the ``-i`` option to send the HTTP response to
-terminal output and the ``-X`` option to specify the correct HTTP
-method.
-
 This operation does not return a response body. An HTTP status code of
 200 (OK) in the response indicates that the request succeeded.
 
  
-**Example: Delete a backup configuration**
+**cURL delete a backup configuration request**
 
 .. code::  
 
-   curl -i -X DELETE https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/backup-configuration/yourBackupConfigurationID \
-   -H "X-Auth-Token: yourAuthToken" 
+   curl -i -X DELETE $API_ENDPOINT/v1.0/$TENANT_ID/backup-configuration/yourBackupConfigurationID \
+   -H "X-Auth-Token: $AUTH_TOKEN" 
 
 To verify that the backup configuration is deleted, list the backup
 configuration details to see ``IsDeleted: True``.
-
  
-**Example: List backup configuration details**
+**cURL list backup configuration details request**
 
 .. code::  
 
-   curl -s -X GET https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/backup-configuration/yourBackupConfigurationID \
-   -H "X-Auth-Token: yourAuthToken" | python -m json.tool
+   curl -s -X GET $API_ENDPOINT/v1.0/$TENANT_ID/backup-configuration/yourBackupConfigurationID \
+   -H "X-Auth-Token: $AUTH_TOKEN" | python -m json.tool
+
+**List backup configuration details response**
 
 .. code::  
 

--- a/rst/dev-guide/cloud-backup-v1/getting-started/examples/get-restore-report.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/examples/get-restore-report.rst
@@ -9,26 +9,18 @@ restore operation and tells you if the operation ran successfully.
 The HTTP request must include a header to specify the authentication
 token.
 
-The cURL request uses the ``-s`` option for silent or quiet mode (no
-progress or error messages shown) and the ``-X`` option to specify the
-request operation to use when communicating with the HTTP server
-(instead of using the default operation).
-
-If you have the tools, you can run the cURL JSON request examples with
-the following option to format the output from cURL: **<cURL JSON
-request example> \| python -m json.tool**.
-
 An HTTP status code of 200 (OK) in the response indicates that the
 request succeeded.
-
  
-**Example: Get a restore report**
+**cURL get a restore report request**
 
 .. code::  
 
-   curl -s -X GET https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/restore/report/yourRestoreID \
-   -H "X-Auth-Token: yourAuthToken" \
+   curl -s -X GET $API_ENDPOINT/v1.0/$TENANT_ID/restore/report/yourRestoreID \
+   -H "X-Auth-Token: $AUTH_TOKEN" \
    -H "Content-Type: application/json" | python -m json.tool
+
+**Get a restore report response**
 
 .. code::  
 

--- a/rst/dev-guide/cloud-backup-v1/getting-started/examples/list-agent-activity.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/examples/list-agent-activity.rst
@@ -13,26 +13,19 @@ types are ``Backup``, ``Cleanup``, and ``Restore``.
 The HTTP request must include a header to specify the authentication
 token.
 
-The cURL request uses the ``-s`` option for silent or quiet mode (no
-progress or error messages shown) and the ``-X`` option to specify the
-request operation to use when communicating with the HTTP server
-(instead of using the default operation).
-
-If you have the tools, you can run the cURL JSON request examples with
-the following option to format the output from cURL: **<cURL JSON
-request example> \| python -m json.tool**.
-
 An HTTP status code of 200 (OK) in the response indicates that the
 request succeeded.
 
  
-**Example: List activity for an agent**
+**cURL list activity for an agent request**
 
 .. code::  
 
-   curl -s -X GET https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/system/activity/yourAgentID /
-   -H "X-Auth-Token: yourAuthToken" \
+   curl -s -X GET $API_ENDPOINT/v1.0/$TENANT_ID/system/activity/yourAgentID /
+   -H "X-Auth-Token: $AUTH_TOKEN" \
    -H "Content-Type: application/json" | python -m json.tool
+
+**List activity for an agent response**
 
 .. code::  
 

--- a/rst/dev-guide/cloud-backup-v1/getting-started/examples/list-agent-details.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/examples/list-agent-details.rst
@@ -11,25 +11,18 @@ details ” <listAgentDetails-d1e01.html>`__ for **yourMachineAgentID**.
 The HTTP request must include a header to specify the authentication
 token.
 
-The cURL request uses the ``-s`` option for silent or quiet mode (no
-progress or error messages shown) and the ``-X`` option to specify the
-request operation to use when communicating with the HTTP server
-(instead of using the default operation).
-
-If you have the tools, you can run the cURL JSON request examples with
-the following option to format the output from cURL: **<cURL JSON
-request example> \| python -m json.tool**.
-
 An HTTP status code of 200 (OK) in the response indicates that the
 request succeeded.
 
  
-**Example: List agent details**
+**cURL list agent details request**
 
 .. code::  
 
-   curl -s -X GET https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/agent/yourMachineAgentID  \
-   -H "X-Auth-Token: yourAuthToken" | python -m json.tool
+   curl -s -X GET $API_ENDPOINT/v1.0/$TENANT_ID/agent/yourMachineAgentID  \
+   -H "X-Auth-Token: $AUTH_TOKEN" | python -m json.tool
+
+**List agent details response**
 
 .. code::  
 

--- a/rst/dev-guide/cloud-backup-v1/getting-started/examples/list-all-agents-for-user.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/examples/list-all-agents-for-user.rst
@@ -27,25 +27,17 @@ requests.
 The HTTP request must include a header to specify the authentication
 token.
 
-The cURL request uses the ``-s`` option for silent or quiet mode (no
-progress or error messages shown) and the ``-X`` option to specify the
-request operation to use when communicating with the HTTP server
-(instead of using the default operation).
-
-If you have the tools, you can run the cURL JSON request examples with
-the following option to format the output from cURL: **<cURL JSON
-request example> \| python -m json.tool**.
-
 An HTTP status code of 200 (OK) indicates that the request succeeded.
 
  
-**Example: List all agents for the user**
+**cURL list all agents for the user request**
 
 .. code::  
 
-   curl -s -X GET https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/user/agents \
-   -H "X-Auth-Token: yourAuthToken" | python -m json.tool
+   curl -s -X GET $API_ENDPOINT/v1.0/$TENANT_ID/user/agents \
+   -H "X-Auth-Token: $AUTH_TOKEN" | python -m json.tool
 
+**List all agents for the user response**
 .. code::  
 
    [

--- a/rst/dev-guide/cloud-backup-v1/getting-started/examples/list-current-backup-configs.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/examples/list-current-backup-configs.rst
@@ -10,25 +10,18 @@ backup configurations for your agent. The output is similar to that in
 The HTTP request must include a header to specify the authentication
 token.
 
-The cURL request uses the ``-s`` option for silent or quiet mode (no
-progress or error messages shown) and the ``-X`` option to specify the
-request operation to use when communicating with the HTTP server
-(instead of using the default operation).
-
-If you have the tools, you can run the cURL JSON request examples with
-the following option to format the output from cURL: **<cURL JSON
-request example> \| python -m json.tool**.
-
 An HTTP status code of 200 (OK) in the response indicates that the
 request succeeded.
 
  
-**Example: List all backup configurations for an agent**
+**cURL list all backup configurations for an agent request**
 
 .. code::  
 
-   curl -s -X GET https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/backup-configuration/system/youMachineAgentID \
-   -H "X-Auth-Token: yourAuthToken" | python -m json.tool
+   curl -s -X GET $API_ENDPOINT/v1.0/$TENANT_ID/backup-configuration/system/youMachineAgentID \
+   -H "X-Auth-Token: $AUTH_TOKEN" | python -m json.tool
+
+**List all backup configurations for an agent response**
 
 .. code::  
 

--- a/rst/dev-guide/cloud-backup-v1/getting-started/examples/restore-backup.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/examples/restore-backup.rst
@@ -13,21 +13,16 @@ value.
 The HTTP request must include a header to specify the authentication
 token.
 
-The cURL request uses the ``-s`` option for silent or quiet mode (no
-progress or error messages shown) and the ``-X`` option to specify the
-request operation to use when communicating with the HTTP server
-(instead of using the default operation).
-
 This operation does not return a response body. An HTTP status code of
 204 (No Content) in the response indicates that the request succeeded.
 
  
-**Example: Start a restore manually**
+**cURL start a restore manually request**
 
 .. code::  
 
-   curl -s -X POST https: //dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/restore/action-requested \
-     -H "X-Auth-Token: yourAuthToken" \
+   curl -s -X POST $API_ENDPOINT/v1.0/$TENANT_ID/restore/action-requested \
+     -H "X-Auth-Token: $AUTH_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{"Action": "StartManual",     
            "Id": 1394  }'
@@ -37,6 +32,8 @@ shown in the following example. Receiving the email is based on the
 ``NotifyRecipients``, ``NotifySuccess``, and ``NotifyFailure``
 parameters that you specify when you create your backup configuration
 (see :ref:`Create a backup configuration <gsg-create-backup-config>`).
+
+**Start a restore manually email**
 
 .. code::  
 

--- a/rst/dev-guide/cloud-backup-v1/getting-started/examples/start-backup.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/examples/start-backup.rst
@@ -15,20 +15,16 @@ job.
 The HTTP request must include a header to specify the authentication
 token.
 
-The cURL request uses the ``-i`` option to send the HTTP response to
-terminal output and the ``-X`` option to specify the correct HTTP
-method.
-
 This operation does not return a response body. An HTTP status code of
 200 (OK) in the response indicates that the request succeeded.
 
  
-**Example: Start a backup manually**
+**cURL start a backup manually request**
 
 .. code::  
 
-   curl -i -X POST https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/backup/action-requested \
-   -H "X-Auth-Token: yourAuthToken"  \
+   curl -i -X POST $API_ENDPOINT/v1.0/$TENANT_ID/backup/action-requested \
+   -H "X-Auth-Token: $AUTH_TOKEN" \
    -H "Content-Type: application/json" \
    -d '{   "Action" : "StartManual",    
             "Id": yourBackupConfigurationId
@@ -36,6 +32,8 @@ This operation does not return a response body. An HTTP status code of
 
 The response comes from the server. The number at the end of the
 response is the ID of the job.
+
+**Start a backup manually response**
 
 .. code::  
 
@@ -51,6 +49,8 @@ in the following example. Receiving the email is based on the
 ``NotifyRecipients``, ``NotifySuccess``, and ``NotifyFailure``
 parameters that you specify when you create your backup configuration
 (see :ref:`Create a backup configuration <gsg-create-backup-config>`).
+
+**Start a backup manually email**
 
 .. code::  
 

--- a/rst/dev-guide/cloud-backup-v1/getting-started/examples/update-configuration.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/examples/update-configuration.rst
@@ -15,25 +15,16 @@ that you used in :ref:`Create a backup configuration <gsg-create-backup-config>`
 The HTTP request must include a header to specify the authentication
 token.
 
-The cURL request uses the ``-s`` option for silent or quiet mode (no
-progress or error messages shown) and the ``-X`` option to specify the
-request operation to use when communicating with the HTTP server
-(instead of using the default operation).
-
-If you have the tools, you can run the cURL JSON request examples with
-the following option to format the output from cURL: **<cURL JSON
-request example> \| python -m json.tool**.
-
 This operation does not return a response body. An HTTP status code of
 200 (OK) in the response indicates that the request succeeded.
 
  
-**Example: Update a backup configuration**
+**cURL update a backup configuration request**
 
 .. code::  
 
-   curl -i -X PUT https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/backup-configuration/yourBackupConfigurationID \
-   -H "X-Auth-Token: yourAuthToken" \
+   curl -i -X PUT $API_ENDPOINT/v1.0/$TENANT_ID/backup-configuration/yourBackupConfigurationID \
+   -H "X-Auth-Token: $AUTH_TOKEN" \
    -H "Content-Type: application/json" \
    -d '{
         "MachineAgentId": 202743,
@@ -73,7 +64,9 @@ You can verify that the configuration is updated by using the following
 cURL request, specifying the same ``BackupConfigurationId`` that you
 used in the update request.
 
+**cURL list a backup configuration request**
+
 .. code::  
 
-   curl -s -X GET https://dfw.backup.api.rackspacecloud.com/v1.0/yourAccountID/backup-configuration/yourBackupConfigurationID \
-   -H "X-Auth-Token: yourAuthToken" | python -m
+   curl -s -X GET $API_ENDPOINT/v1.0/$TENANT_ID/backup-configuration/yourBackupConfigurationID \
+   -H "X-Auth-Token: $AUTH_TOKEN" | python -m

--- a/rst/dev-guide/cloud-backup-v1/getting-started/using-cloud-backup.rst
+++ b/rst/dev-guide/cloud-backup-v1/getting-started/using-cloud-backup.rst
@@ -11,6 +11,13 @@ cURL, followed by the response.
 
 Before running the examples, review the :ref:`Cloud Backup concepts<concepts>`.
 
+.. note:: 
+     These examples use the ``$API_ENDPOINT``, ``$AUTH_TOKEN``, and ``$TENANT_ID`` environment 
+     variables to specify the API endpoint, authentication token, and project ID values 
+     for accessing the service. Make sure you 
+     :ref:`configure these variables<configure-environment-variables>` before running the 
+     code samples. 
+
 For more information about all Cloud Files operations, see the
 :ref:`API reference <api-reference>`. 
 


### PR DESCRIPTION
Also added new note mentioned by Margaret in today's meeting pointing to Cloud Identity for explanation of service catalog.
And replace authenticate.rst in General API Info with model, shorter file.