### PR TITLE
Adding v2 documentation for vault state

### DIFF
--- a/api-docs/cloud-backup-v2/api-operations/methods/get-list-agents-for-a-project-v2-project-id-agents.rst
+++ b/api-docs/cloud-backup-v2/api-operations/methods/get-list-agents-for-a-project-v2-project-id-agents.rst
@@ -193,6 +193,8 @@ This table shows the body parameters for the response:
 +-----------------------------+------------------------+-----------------------+
 |agents.vault.\ **name**      |String                  |Name of the vault.     |
 +-----------------------------+------------------------+-----------------------+
+|agents.vault.\ **state**     |String                  |State of the vault.    |
++-----------------------------+------------------------+-----------------------+
 |agents.vault.\ **flavor**    |String                  |Flavor for the vault.  |
 +-----------------------------+------------------------+-----------------------+
 |agents.vault.\ **encrypted** |String                  |Specifies whether the  |
@@ -288,6 +290,7 @@ This table shows the body parameters for the response:
                "vault": {
                    "id": "7cd999c3-a0c3-4985-99d4-42b544685456",
                    "name": "phoenix_7cd999c3-a0c3-4985-99d4-42b544685456",
+                   "state": "created",
                    "flavor": "swift",
                    "encrypted": true,
                    "region": "DFW",
@@ -338,7 +341,3 @@ This table shows the body parameters for the response:
            }
        ]
    }
-
-
-
-

--- a/api-docs/cloud-backup-v2/api-operations/methods/get-list-details-about-an-agent-v2-project-id-agents-agent-id.rst
+++ b/api-docs/cloud-backup-v2/api-operations/methods/get-list-details-about-an-agent-v2-project-id-agents-agent-id.rst
@@ -179,6 +179,8 @@ This table shows the body parameters for the response:
 +--------------------------+-------------------------+-------------------------+
 |vault.\ **name**          |String                   |Name of the vault.       |
 +--------------------------+-------------------------+-------------------------+
+|vault.\ **state**         |String                   |State of the vault.      |
++--------------------------+-------------------------+-------------------------+
 |vault.\ **flavor**        |String                   |Flavor for the vault.    |
 +--------------------------+-------------------------+-------------------------+
 |vault.\ **encrypted**     |String                   |Specifies whether the    |
@@ -274,6 +276,7 @@ This table shows the body parameters for the response:
        "vault": {
            "id": "7cd999c3-a0c3-4985-99d4-42b544685456",
            "name": "phoenix_7cd999c3-a0c3-4985-99d4-42b544685456",
+           "state": "created",
            "flavor": "swift",
            "encrypted": true,
            "region": "DFW",
@@ -322,7 +325,3 @@ This table shows the body parameters for the response:
            }
        ]
    }
-
-
-
-

--- a/api-docs/cloud-backup-v2/api-operations/methods/post-register-an-agent-v2-project-id-agents.rst
+++ b/api-docs/cloud-backup-v2/api-operations/methods/post-register-an-agent-v2-project-id-agents.rst
@@ -207,7 +207,7 @@ This table shows the body parameters for the request:
        },
        "vault": {
            "use_internal": true
-       }    
+       }
    }
 
 
@@ -298,6 +298,8 @@ This table shows the body parameters for the response:
 |vault.\ **id**            |String                   |ID of the vault.         |
 +--------------------------+-------------------------+-------------------------+
 |vault.\ **name**          |String                   |Name of the vault.       |
++--------------------------+-------------------------+-------------------------+
+|vault.\ **state**         |String                   |State of the vault.      |
 +--------------------------+-------------------------+-------------------------+
 |vault.\ **flavor**        |String                   |Flavor of the vault.     |
 +--------------------------+-------------------------+-------------------------+
@@ -394,6 +396,7 @@ This table shows the body parameters for the response:
        "vault": {
            "id": "7cd999c3-a0c3-4985-99d4-42b544685456",
            "name": "phoenix_7cd999c3-a0c3-4985-99d4-42b544685456",
+           "state": "created",
            "flavor": "swift",
            "encrypted": true,
            "region": "DFW",
@@ -442,7 +445,3 @@ This table shows the body parameters for the response:
            }
        ]
    }
-
-
-
-


### PR DESCRIPTION
Adds a new `state` field for the agent's vault information.

@BryanSD Tagging you on this for visibility.

@cyrichardson Let me know if I'm missing anything important!